### PR TITLE
gulpfileのheaderにs3デプロイ用の文を追記

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,6 +28,7 @@ const config = {
   region: process.env.AWS_DEFAULT_REGION,
   headers: {
     /* 'Cache-Control': 'max-age=315360000, no-transform, public', */
+    'x-amz-acl': 'private'
   },
 
   // 適切なデフォルト値 - これらのファイル及びディレクトリは gitignore されている


### PR DESCRIPTION
gulpfileのheaderにs3デプロイ用の文を追記
 'x-amz-acl': 'private'